### PR TITLE
Update README to include information about new `nodejs-backend` template

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,12 +253,18 @@ Used for Node.js backend applications. The template builds using `npm`, and does
 not assume you use TypeScript.
 
 ```bash
-nix flake init -t github:ALT-F4-LLC/kickstart.nix#rust
+nix flake init -t github:ALT-F4-LLC/kickstart.nix#nodejs-backend
 ```
 
 To update your dependencies, install/upgrade them as normal via NPM, then use
 the [`prefetch-npm-deps` package from nixpkgs](https://github.com/NixOS/nixpkgs/blob/master/doc/languages-frameworks/javascript.section.md#prefetch-npm-deps-javascript-buildnpmpackage-prefetch-npm-deps)
-to generate a new `npmDepsHash` value in `packages.default` in the Flake.
+to generate a new `npmDepsHash` value for `packages.default` in the Flake.
+
+```bash
+$ nix shell 'nixpkgs#prefetch-npm-deps' -c prefetch-npm-deps package-lock.json
+...
+sha256-nTTzkQEdnwWEQ/3uy8hUbPsRvzM53xuoJHoQhR3E/zk=
+```
 
 > [!TIP]
 > To add TypeScript, install it with `npm install --save-dev typescript`, add a

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Kickstart your Nix environments.
     - [Python (application)](#python-application)
     - [Python (package)](#python-package)
     - [Rust](#rust)
+    - [Node.js (backend)](#nodejs-backend)
 - Systems
     - [macOS (desktop)](#macos-desktop)
     - [NixOS (desktop)](#nixos-desktop)
@@ -245,6 +246,24 @@ Used for Rust applications.
 ```bash
 nix flake init -t github:ALT-F4-LLC/kickstart.nix#rust
 ```
+
+#### Node.js (backend)
+
+Used for Node.js backend applications. The template builds using `npm`, and does
+not assume you use TypeScript.
+
+```bash
+nix flake init -t github:ALT-F4-LLC/kickstart.nix#rust
+```
+
+To update your dependencies, install/upgrade them as normal via NPM, then use
+the [`prefetch-npm-deps` package from nixpkgs](https://github.com/NixOS/nixpkgs/blob/master/doc/languages-frameworks/javascript.section.md#prefetch-npm-deps-javascript-buildnpmpackage-prefetch-npm-deps)
+to generate a new `npmDepsHash` value in `packages.default` in the Flake.
+
+> [!TIP]
+> To add TypeScript, install it with `npm install --save-dev typescript`, add a
+> `build` script to `package.json` that calls `tsc`, and then remove
+> `dontNpmBuild = true;` from `packages.default` in your Flake.
 
 ### Systems
 

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ Kickstart your Nix environments.
     - [Bash](#bash)
     - [Go (module)](#go-module)
     - [Go (package)](#go-package)
+    - [Node.js (backend)](#nodejs-backend)
     - [OCaml](#ocaml)
     - [Python (application)](#python-application)
     - [Python (package)](#python-package)
     - [Rust](#rust)
-    - [Node.js (backend)](#nodejs-backend)
 - Systems
     - [macOS (desktop)](#macos-desktop)
     - [NixOS (desktop)](#nixos-desktop)
@@ -215,6 +215,30 @@ Used for legacy Go apps **not** setup with `go.mod` system. To build modern Go a
 nix flake init -t github:ALT-F4-LLC/kickstart.nix#go-pkg
 ```
 
+#### Node.js (backend)
+
+Used for Node.js backend applications. The template builds using `npm`, and does
+not assume you use TypeScript.
+
+```bash
+nix flake init -t github:ALT-F4-LLC/kickstart.nix#nodejs-backend
+```
+
+To update your dependencies, install/upgrade them as normal via NPM, then use
+the [`prefetch-npm-deps` package from nixpkgs](https://github.com/NixOS/nixpkgs/blob/master/doc/languages-frameworks/javascript.section.md#prefetch-npm-deps-javascript-buildnpmpackage-prefetch-npm-deps)
+to generate a new `npmDepsHash` value for `packages.default` in the Flake.
+
+```bash
+$ nix shell 'nixpkgs#prefetch-npm-deps' -c prefetch-npm-deps package-lock.json
+...
+sha256-nTTzkQEdnwWEQ/3uy8hUbPsRvzM53xuoJHoQhR3E/zk=
+```
+
+> [!TIP]
+> To add TypeScript, install it with `npm install --save-dev typescript`, add a
+> `build` script to `package.json` that calls `tsc`, and then remove
+> `dontNpmBuild = true;` from `packages.default` in your Flake.
+
 #### OCaml
 
 Used for OCaml applications.
@@ -246,30 +270,6 @@ Used for Rust applications.
 ```bash
 nix flake init -t github:ALT-F4-LLC/kickstart.nix#rust
 ```
-
-#### Node.js (backend)
-
-Used for Node.js backend applications. The template builds using `npm`, and does
-not assume you use TypeScript.
-
-```bash
-nix flake init -t github:ALT-F4-LLC/kickstart.nix#nodejs-backend
-```
-
-To update your dependencies, install/upgrade them as normal via NPM, then use
-the [`prefetch-npm-deps` package from nixpkgs](https://github.com/NixOS/nixpkgs/blob/master/doc/languages-frameworks/javascript.section.md#prefetch-npm-deps-javascript-buildnpmpackage-prefetch-npm-deps)
-to generate a new `npmDepsHash` value for `packages.default` in the Flake.
-
-```bash
-$ nix shell 'nixpkgs#prefetch-npm-deps' -c prefetch-npm-deps package-lock.json
-...
-sha256-nTTzkQEdnwWEQ/3uy8hUbPsRvzM53xuoJHoQhR3E/zk=
-```
-
-> [!TIP]
-> To add TypeScript, install it with `npm install --save-dev typescript`, add a
-> `build` script to `package.json` that calls `tsc`, and then remove
-> `dontNpmBuild = true;` from `packages.default` in your Flake.
 
 ### Systems
 


### PR DESCRIPTION
See title of PR. This adds a section to the README about the new Node.js Backend template added in #32, as well as some basic (but common) usage information.