### PR TITLE
docs: fix setup command for cpp-cmake

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ nix flake init -t github:ALT-F4-LLC/kickstart.nix#bash
 Used for C++ projects using CMake as a build system.
 
 ```bash
-nix flake init -t github:ALT-F4-LLC/kickstart.nix#cmake-cpp
+nix flake init -t github:ALT-F4-LLC/kickstart.nix#cpp-cmake
 ```
 
 #### Go (module)


### PR DESCRIPTION
This fixes the typo in the C++/CMake template documentation in the README, changing the template name to `cpp-cmake`.