### PR TITLE
Update GitHub Actions and Nix Configurations

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base",
+    ":semanticCommitTypeAll(chore)"
+  ],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "extends": [
+      "schedule:weekly"
+    ]
+  },
+  "nix": {
+    "enabled": true
+  }
+}

--- a/.github/workflows/flake-home-manager.yml
+++ b/.github/workflows/flake-home-manager.yml
@@ -6,27 +6,28 @@ on:
     branches:
       - main
 
+env:
+  CACHIX_BINARY_CACHE: altf4llc-os
+
 jobs:
   darwin:
     runs-on: macos-latest
     steps:
       - uses: DeterminateSystems/nix-installer-action@main
-      - uses: cachix/cachix-action@v12
+      - uses: cachix/cachix-action@v14
         with:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          name: altf4llc-os
-      - uses: actions/checkout@v3
-      - run: cachix use "altf4llc-os"
-      - run: nix develop -c just cache-build 'build-home-manager "x86_64-darwin"'
+          name: ${{ env.CACHIX_BINARY_CACHE }}
+      - uses: actions/checkout@v4
+      - run: nix develop -c just build-home-manager "x86_64-darwin"
 
   linux:
     runs-on: ubuntu-latest
     steps:
       - uses: DeterminateSystems/nix-installer-action@main
-      - uses: cachix/cachix-action@v12
+      - uses: cachix/cachix-action@v14
         with:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          name: altf4llc-os
-      - uses: actions/checkout@v3
-      - run: cachix use "altf4llc-os"
-      - run: nix develop -c just cache-build 'build-home-manager "x86_64-linux"'
+          name: ${{ env.CACHIX_BINARY_CACHE }}
+      - uses: actions/checkout@v4
+      - run: nix develop -c just build-home-manager "x86_64-linux"

--- a/.github/workflows/flake-home-manager.yml
+++ b/.github/workflows/flake-home-manager.yml
@@ -21,8 +21,8 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
           name: ${{ env.CACHIX_BINARY_CACHE }}
       - uses: actions/checkout@v4
-      - run: |
-          nix develop -c just build-home-manager "x86_64-darwin" "${{ runner.temp }}"
+      - run: mkdir -p "${{ runner.temp }}/build"
+      - run: nix develop -c just build-home-manager "x86_64-darwin" "${{ runner.temp }}/build"
 
   linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/flake-home-manager.yml
+++ b/.github/workflows/flake-home-manager.yml
@@ -8,7 +8,6 @@ on:
 
 env:
   CACHIX_BINARY_CACHE: altf4llc-os
-  TEMP_DIR: ${{ runner.temp }}/build
 
 jobs:
   darwin:
@@ -22,8 +21,8 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
           name: ${{ env.CACHIX_BINARY_CACHE }}
       - uses: actions/checkout@v4
-      - run: mkdir -p "${{ env.TEMP_DIR }}"
-      - run: nix develop -c just build-home-manager "x86_64-darwin" "${{ env.TEMP_DIR }}"
+      - run: mkdir -p "${{ runner.temp }}/build"
+      - run: nix develop -c just build-home-manager "x86_64-darwin" "${{ runner.temp }}/build"
 
   linux:
     runs-on: ubuntu-latest
@@ -36,5 +35,5 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
           name: ${{ env.CACHIX_BINARY_CACHE }}
       - uses: actions/checkout@v4
-      - run: mkdir -p "${{ env.TEMP_DIR }}"
-      - run: nix develop -c just build-home-manager "x86_64-linux" "${{ env.TEMP_DIR }}"
+      - run: mkdir -p "${{ runner.temp }}/build"
+      - run: nix develop -c just build-home-manager "x86_64-linux" "${{ runner.temp }}/build"

--- a/.github/workflows/flake-home-manager.yml
+++ b/.github/workflows/flake-home-manager.yml
@@ -21,7 +21,9 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
           name: ${{ env.CACHIX_BINARY_CACHE }}
       - uses: actions/checkout@v4
-      - run: nix develop -c just build-home-manager "x86_64-darwin"
+      - run: mkdir -p "$PWD/.tmp"
+      - run: |
+          nix develop -c just build-home-manager "x86_64-darwin" "$PWD/.tmp"
 
   linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/flake-home-manager.yml
+++ b/.github/workflows/flake-home-manager.yml
@@ -21,9 +21,7 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
           name: ${{ env.CACHIX_BINARY_CACHE }}
       - uses: actions/checkout@v4
-      - run: mkdir -p "$PWD/.tmp"
-      - run: |
-          nix develop -c just build-home-manager "x86_64-darwin" "$PWD/.tmp"
+      - run: nix develop -c just build-home-manager "x86_64-darwin"
 
   linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/flake-home-manager.yml
+++ b/.github/workflows/flake-home-manager.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   CACHIX_BINARY_CACHE: altf4llc-os
+  TEMP_DIR: ${{ runner.temp }}/build
 
 jobs:
   darwin:
@@ -21,8 +22,8 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
           name: ${{ env.CACHIX_BINARY_CACHE }}
       - uses: actions/checkout@v4
-      - run: mkdir -p "${{ runner.temp }}/build"
-      - run: nix develop -c just build-home-manager "x86_64-darwin" "${{ runner.temp }}/build"
+      - run: mkdir -p "${{ env.TEMP_DIR }}"
+      - run: nix develop -c just build-home-manager "x86_64-darwin" "${{ env.TEMP_DIR }}"
 
   linux:
     runs-on: ubuntu-latest
@@ -35,4 +36,5 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
           name: ${{ env.CACHIX_BINARY_CACHE }}
       - uses: actions/checkout@v4
-      - run: nix develop -c just build-home-manager "x86_64-linux"
+      - run: mkdir -p "${{ env.TEMP_DIR }}"
+      - run: nix develop -c just build-home-manager "x86_64-linux" "${{ env.TEMP_DIR }}"

--- a/.github/workflows/flake-home-manager.yml
+++ b/.github/workflows/flake-home-manager.yml
@@ -13,7 +13,9 @@ jobs:
   darwin:
     runs-on: macos-latest
     steps:
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: cachix/install-nix-action@v27
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@v14
         with:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
@@ -24,7 +26,9 @@ jobs:
   linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: cachix/install-nix-action@v27
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@v14
         with:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/.github/workflows/flake-home-manager.yml
+++ b/.github/workflows/flake-home-manager.yml
@@ -21,7 +21,8 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
           name: ${{ env.CACHIX_BINARY_CACHE }}
       - uses: actions/checkout@v4
-      - run: nix develop -c just build-home-manager "x86_64-darwin"
+      - run: |
+          nix develop -c just build-home-manager "x86_64-darwin" "${{ runner.temp }}"
 
   linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/flake-language.yml
+++ b/.github/workflows/flake-language.yml
@@ -33,7 +33,9 @@ jobs:
           - zig
           - vite-react
     steps:
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: cachix/install-nix-action@v27
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@v14
         with:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
@@ -61,7 +63,9 @@ jobs:
           - swiftpm
           - zig
     steps:
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: cachix/install-nix-action@v27
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@v14
         with:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/.github/workflows/flake-language.yml
+++ b/.github/workflows/flake-language.yml
@@ -8,7 +8,6 @@ on:
 
 env:
   CACHIX_BINARY_CACHE: altf4llc-os
-  TEMP_DIR: ${{ runner.temp }}/build
 
 jobs:
   default:
@@ -42,7 +41,8 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
           name: ${{ env.CACHIX_BINARY_CACHE }}
       - uses: actions/checkout@v4
-      - run: nix develop -c just build-language "${{ matrix.template }}" "default" "${{ env.TEMP_DIR }}"
+      - run: mkdir -p "${{ runner.temp }}/build"
+      - run: nix develop -c just build-language "${{ matrix.template }}" "default" "${{ runner.temp }}/build"
 
   docker:
     runs-on: ubuntu-latest
@@ -72,4 +72,5 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
           name: ${{ env.CACHIX_BINARY_CACHE }}
       - uses: actions/checkout@v4
-      - run: nix develop -c just build-language "${{ matrix.template }}" "docker" "${{ env.TEMP_DIR }}"
+      - run: mkdir -p "${{ runner.temp }}/build"
+      - run: nix develop -c just build-language "${{ matrix.template }}" "docker" "${{ runner.temp }}/build"

--- a/.github/workflows/flake-language.yml
+++ b/.github/workflows/flake-language.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   CACHIX_BINARY_CACHE: altf4llc-os
+  TEMP_DIR: ${{ runner.temp }}/build
 
 jobs:
   default:
@@ -41,7 +42,7 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
           name: ${{ env.CACHIX_BINARY_CACHE }}
       - uses: actions/checkout@v4
-      - run: nix develop -c just build-language "${{ matrix.template }}" "default"
+      - run: nix develop -c just build-language "${{ matrix.template }}" "default" "${{ env.TEMP_DIR }}"
 
   docker:
     runs-on: ubuntu-latest
@@ -71,4 +72,4 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
           name: ${{ env.CACHIX_BINARY_CACHE }}
       - uses: actions/checkout@v4
-      - run: nix develop -c just build-language "${{ matrix.template }}" "docker"
+      - run: nix develop -c just build-language "${{ matrix.template }}" "docker" "${{ env.TEMP_DIR }}"

--- a/.github/workflows/flake-language.yml
+++ b/.github/workflows/flake-language.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+env:
+  CACHIX_BINARY_CACHE: altf4llc-os
+
 jobs:
   default:
     runs-on: ubuntu-latest
@@ -31,13 +34,12 @@ jobs:
           - vite-react
     steps:
       - uses: DeterminateSystems/nix-installer-action@main
-      - uses: cachix/cachix-action@v12
+      - uses: cachix/cachix-action@v14
         with:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          name: altf4llc-os
-      - uses: actions/checkout@v3
-      - run: cachix use "altf4llc-os"
-      - run: nix develop -c just cache-build 'build-language "${{ matrix.template }}" "default"'
+          name: ${{ env.CACHIX_BINARY_CACHE }}
+      - uses: actions/checkout@v4
+      - run: nix develop -c just build-language "${{ matrix.template }}" "default"
 
   docker:
     runs-on: ubuntu-latest
@@ -60,10 +62,9 @@ jobs:
           - zig
     steps:
       - uses: DeterminateSystems/nix-installer-action@main
-      - uses: cachix/cachix-action@v12
+      - uses: cachix/cachix-action@v14
         with:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          name: altf4llc-os
-      - uses: actions/checkout@v3
-      - run: cachix use "altf4llc-os"
-      - run: nix develop -c just cache-build 'build-language "${{ matrix.template }}" "docker"'
+          name: ${{ env.CACHIX_BINARY_CACHE }}
+      - uses: actions/checkout@v4
+      - run: nix develop -c just build-language "${{ matrix.template }}" "docker"

--- a/.github/workflows/flake-system.yml
+++ b/.github/workflows/flake-system.yml
@@ -21,7 +21,7 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
           name: ${{ env.CACHIX_BINARY_CACHE }}
       - uses: actions/checkout@v4
-      - run: nix develop -c just build-darwin "x86_64"
+      - run: nix develop -c just build-darwin "x86_64" "${{ runner.temp }}"
 
   nixos-desktop:
     strategy:

--- a/.github/workflows/flake-system.yml
+++ b/.github/workflows/flake-system.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   CACHIX_BINARY_CACHE: altf4llc-os
+  TEMP_DIR: ${{ runner.temp }}/build
 
 jobs:
   darwin:
@@ -21,8 +22,8 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
           name: ${{ env.CACHIX_BINARY_CACHE }}
       - uses: actions/checkout@v4
-      - run: mkdir -p "${{ runner.temp }}/build"
-      - run: nix develop -c just build-darwin "x86_64" "${{ runner.temp }}/build"
+      - run: mkdir -p "${{ env.TEMP_DIR }}"
+      - run: nix develop -c just build-darwin "x86_64" "${{ env.TEMP_DIR }}"
 
   nixos-desktop:
     strategy:
@@ -40,7 +41,8 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
           name: ${{ env.CACHIX_BINARY_CACHE }}
       - uses: actions/checkout@v4
-      - run: nix develop -c just build-nixos-desktop "x86_64" "${{ matrix.desktop }}"
+      - run: mkdir -p "${{ env.TEMP_DIR }}"
+      - run: nix develop -c just build-nixos-desktop "x86_64" "${{ matrix.desktop }}" "${{ env.TEMP_DIR }}"
 
   nixos-minimal:
     runs-on: ubuntu-latest
@@ -53,4 +55,5 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
           name: ${{ env.CACHIX_BINARY_CACHE }}
       - uses: actions/checkout@v4
-      - run: nix develop -c just build-nixos-minimal "x86_64"
+      - run: mkdir -p "${{ env.TEMP_DIR }}"
+      - run: nix develop -c just build-nixos-minimal "x86_64" "${{ env.TEMP_DIR }}"

--- a/.github/workflows/flake-system.yml
+++ b/.github/workflows/flake-system.yml
@@ -21,7 +21,9 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
           name: ${{ env.CACHIX_BINARY_CACHE }}
       - uses: actions/checkout@v4
-      - run: nix develop -c just build-darwin "x86_64"
+      - run: mkdir -p "$PWD/.tmp"
+      - run: |
+          nix develop -c just build-darwin "x86_64" "$PWD/.tmp"
 
   nixos-desktop:
     strategy:

--- a/.github/workflows/flake-system.yml
+++ b/.github/workflows/flake-system.yml
@@ -21,7 +21,8 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
           name: ${{ env.CACHIX_BINARY_CACHE }}
       - uses: actions/checkout@v4
-      - run: nix develop -c just build-darwin "x86_64" "${{ runner.temp }}"
+      - run: mkdir -p "${{ runner.temp }}/build"
+      - run: nix develop -c just build-darwin "x86_64" "${{ runner.temp }}/build"
 
   nixos-desktop:
     strategy:

--- a/.github/workflows/flake-system.yml
+++ b/.github/workflows/flake-system.yml
@@ -13,7 +13,9 @@ jobs:
   darwin:
     runs-on: macos-latest
     steps:
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: cachix/install-nix-action@v27
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@v14
         with:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
@@ -29,7 +31,9 @@ jobs:
           - plasma5
     runs-on: ubuntu-latest
     steps:
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: cachix/install-nix-action@v27
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@v14
         with:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
@@ -40,7 +44,9 @@ jobs:
   nixos-minimal:
     runs-on: ubuntu-latest
     steps:
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: cachix/install-nix-action@v27
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@v14
         with:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/.github/workflows/flake-system.yml
+++ b/.github/workflows/flake-system.yml
@@ -6,18 +6,20 @@ on:
     branches:
       - main
 
+env:
+  CACHIX_BINARY_CACHE: altf4llc-os
+
 jobs:
   darwin:
     runs-on: macos-latest
     steps:
       - uses: DeterminateSystems/nix-installer-action@main
-      - uses: cachix/cachix-action@v12
+      - uses: cachix/cachix-action@v14
         with:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          name: altf4llc-os
-      - uses: actions/checkout@v3
-      - run: cachix use "altf4llc-os"
-      - run: nix develop -c just cache-build 'build-darwin "x86_64"'
+          name: ${{ env.CACHIX_BINARY_CACHE }}
+      - uses: actions/checkout@v4
+      - run: nix develop -c just build-darwin "x86_64"
 
   nixos-desktop:
     strategy:
@@ -28,22 +30,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: DeterminateSystems/nix-installer-action@main
-      - uses: cachix/cachix-action@v12
+      - uses: cachix/cachix-action@v14
         with:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          name: altf4llc-os
-      - uses: actions/checkout@v3
-      - run: cachix use "altf4llc-os"
-      - run: nix develop -c just cache-build 'build-nixos-desktop "x86_64" "${{ matrix.desktop }}"'
+          name: ${{ env.CACHIX_BINARY_CACHE }}
+      - uses: actions/checkout@v4
+      - run: nix develop -c just build-nixos-desktop "x86_64" "${{ matrix.desktop }}"
 
   nixos-minimal:
     runs-on: ubuntu-latest
     steps:
       - uses: DeterminateSystems/nix-installer-action@main
-      - uses: cachix/cachix-action@v12
+      - uses: cachix/cachix-action@v14
         with:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          name: altf4llc-os
-      - uses: actions/checkout@v3
-      - run: cachix use "altf4llc-os"
-      - run: nix develop -c just cache-build 'build-nixos-minimal "x86_64"'
+          name: ${{ env.CACHIX_BINARY_CACHE }}
+      - uses: actions/checkout@v4
+      - run: nix develop -c just build-nixos-minimal "x86_64"

--- a/.github/workflows/flake-system.yml
+++ b/.github/workflows/flake-system.yml
@@ -8,7 +8,6 @@ on:
 
 env:
   CACHIX_BINARY_CACHE: altf4llc-os
-  TEMP_DIR: ${{ runner.temp }}/build
 
 jobs:
   darwin:
@@ -22,8 +21,8 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
           name: ${{ env.CACHIX_BINARY_CACHE }}
       - uses: actions/checkout@v4
-      - run: mkdir -p "${{ env.TEMP_DIR }}"
-      - run: nix develop -c just build-darwin "x86_64" "${{ env.TEMP_DIR }}"
+      - run: mkdir -p "${{ runner.temp }}/build"
+      - run: nix develop -c just build-darwin "x86_64" "${{ runner.temp }}/build"
 
   nixos-desktop:
     strategy:
@@ -41,8 +40,8 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
           name: ${{ env.CACHIX_BINARY_CACHE }}
       - uses: actions/checkout@v4
-      - run: mkdir -p "${{ env.TEMP_DIR }}"
-      - run: nix develop -c just build-nixos-desktop "x86_64" "${{ matrix.desktop }}" "${{ env.TEMP_DIR }}"
+      - run: mkdir -p "${{ runner.temp }}/build"
+      - run: nix develop -c just build-nixos-desktop "x86_64" "${{ matrix.desktop }}" "${{ runner.temp }}/build"
 
   nixos-minimal:
     runs-on: ubuntu-latest
@@ -55,5 +54,5 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
           name: ${{ env.CACHIX_BINARY_CACHE }}
       - uses: actions/checkout@v4
-      - run: mkdir -p "${{ env.TEMP_DIR }}"
-      - run: nix develop -c just build-nixos-minimal "x86_64" "${{ env.TEMP_DIR }}"
+      - run: mkdir -p "${{ runner.temp }}/build"
+      - run: nix develop -c just build-nixos-minimal "x86_64" "${{ runner.temp }}/build"

--- a/.github/workflows/flake-system.yml
+++ b/.github/workflows/flake-system.yml
@@ -21,9 +21,7 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
           name: ${{ env.CACHIX_BINARY_CACHE }}
       - uses: actions/checkout@v4
-      - run: mkdir -p "$PWD/.tmp"
-      - run: |
-          nix develop -c just build-darwin "x86_64" "$PWD/.tmp"
+      - run: nix develop -c just build-darwin "x86_64"
 
   nixos-desktop:
     strategy:

--- a/.github/workflows/flake.yml
+++ b/.github/workflows/flake.yml
@@ -13,7 +13,9 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-    - uses: DeterminateSystems/nix-installer-action@main
+    - uses: cachix/install-nix-action@v27
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
     - uses: cachix/cachix-action@v14
       with:
         authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/.github/workflows/flake.yml
+++ b/.github/workflows/flake.yml
@@ -6,17 +6,17 @@ on:
     branches:
       - main
 
+env:
+  CACHIX_BINARY_CACHE: altf4llc-os
+
 jobs:
   check:
     runs-on: ubuntu-latest
     steps:
     - uses: DeterminateSystems/nix-installer-action@main
-    - uses: cachix/cachix-action@v12
+    - uses: cachix/cachix-action@v14
       with:
         authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-        name: altf4llc-os
-    - uses: actions/checkout@v3
-    - run: cachix use "altf4llc-os"
+        name: ${{ env.CACHIX_BINARY_CACHE }}
+    - uses: actions/checkout@v4
     - run: nix develop -c just check
-    - run: nix develop -c just cache-inputs
-    - run: nix develop -c just cache-shell

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1709336216,
-        "narHash": "sha256-Dt/wOWeW6Sqm11Yh+2+t0dfEWxoMxGBvv3JpIocFl9E=",
+        "lastModified": 1712014858,
+        "narHash": "sha256-sB4SWl2lX95bExY2gMFG5HIzvva5AVMJd4Igm+GpZNw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f7b3c975cf067e56e7cda6cb098ebe3fb4d74ca2",
+        "rev": "9126214d0a59633752a136528f5f3b9aa8565b7d",
         "type": "github"
       },
       "original": {
@@ -19,11 +19,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1711163522,
-        "narHash": "sha256-YN/Ciidm+A0fmJPWlHBGvVkcarYWSC+s3NTPk/P+q3c=",
+        "lastModified": 1712963716,
+        "narHash": "sha256-WKm9CvgCldeIVvRz87iOMi8CFVB1apJlkUT4GGvA0iM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "44d0940ea560dee511026a53f0e2e2cde489b4d4",
+        "rev": "cfd6b5fc90b15709b780a5a1619695a88505a176",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
     "nixpkgs-lib": {
       "locked": {
         "dir": "lib",
-        "lastModified": 1709237383,
-        "narHash": "sha256-cy6ArO4k5qTx+l5o+0mL9f5fa86tYUX3ozE1S+Txlds=",
+        "lastModified": 1711703276,
+        "narHash": "sha256-iMUFArF0WCatKK6RzfUJknjem0H9m4KgorO/p3Dopkk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1536926ef5621b09bba54035ae2bb6d806d72ac8",
+        "rev": "d8fe5e6c92d0d190646fb9f1056741a229980089",
         "type": "github"
       },
       "original": {

--- a/justfile
+++ b/justfile
@@ -32,23 +32,23 @@ build-home-manager system="x86_64-linux" temp_dir="$(mktemp -d)":
     ls -alh $TEMP_DIR
     just build "$TEMP_DIR#homeConfigurations.{{ system }}.activationPackage"
 
-build-language language profile="default":
+build-language language profile="default" temp_dir="$(mktemp -d)":
     #!/usr/bin/env bash
     set -euxo pipefail
-    TEMP_DIR=$(just build-template "{{ language }}")
+    TEMP_DIR=$(just build-template "{{ language }}" "{{ temp_dir }}")
     ls -alh $TEMP_DIR
     just build "$TEMP_DIR"
 
-build-nixos-desktop system="x86_64" desktop="gnome":
+build-nixos-desktop system="x86_64" desktop="gnome" temp_dir="$(mktemp -d)":
     #!/usr/bin/env bash
     set -euxo pipefail
-    TEMP_DIR=$(just build-template "nixos-desktop-{{ desktop }}")
+    TEMP_DIR=$(just build-template "nixos-desktop-{{ desktop }}" "{{ temp_dir }}")
     ls -alh $TEMP_DIR
     just build "$TEMP_DIR#nixosConfigurations.{{ system }}.config.system.build.toplevel"
 
-build-nixos-minimal system="x86_64":
+build-nixos-minimal system="x86_64" temp_dir="$(mktemp -d)":
     #!/usr/bin/env bash
     set -euxo pipefail
-    TEMP_DIR=$(just build-template "nixos-minimal")
+    TEMP_DIR=$(just build-template "nixos-minimal" "{{ temp_dir }}")
     ls -alh $TEMP_DIR
     just build "$TEMP_DIR#nixosConfigurations.{{ system }}.config.system.build.toplevel"

--- a/justfile
+++ b/justfile
@@ -1,14 +1,14 @@
 _default:
     just --list
 
+check:
+    nix flake check
+
 build profile:
     #!/usr/bin/env bash
     set -euxo pipefail
     nix build --json --no-link --print-build-logs "{{ profile }}" \
     | jq -r ".[0].outputs.out"
-
-check:
-    nix flake check
 
 build-template template temp_dir="$(mktemp -d)":
     #!/usr/bin/env bash
@@ -18,17 +18,17 @@ build-template template temp_dir="$(mktemp -d)":
     cp --no-preserve=mode -r $OUTPUT_DIR/* $TEMP_DIR/.
     echo $TEMP_DIR
 
-build-darwin system="x86_64":
+build-darwin system="x86_64" temp_dir="$(mktemp -d)":
     #!/usr/bin/env bash
     set -euxo pipefail
-    TEMP_DIR=$(just build-template "darwin")
+    TEMP_DIR=$(just build-template "darwin" "{{ temp_dir }}")
     ls -alh $TEMP_DIR
     just build "$TEMP_DIR#darwinConfigurations.{{ system }}.config.system.build.toplevel"
 
-build-home-manager system="x86_64-linux":
+build-home-manager system="x86_64-linux" temp_dir="$(mktemp -d)":
     #!/usr/bin/env bash
     set -euxo pipefail
-    TEMP_DIR=$(just build-template "home-manager")
+    TEMP_DIR=$(just build-template "home-manager" "{{ temp_dir }}")
     ls -alh $TEMP_DIR
     just build "$TEMP_DIR#homeConfigurations.{{ system }}.activationPackage"
 

--- a/justfile
+++ b/justfile
@@ -6,18 +6,6 @@ _default:
 build profile:
     nix build --json --no-link --print-build-logs "{{ profile }}"
 
-cache-build recipe cache_name="altf4llc-os":
-    just {{ recipe }} | jq -r '.[].outputs | to_entries[].value' | cachix push {{ cache_name }}
-
-cache-inputs cache_name="altf4llc-os":
-    nix flake archive --json \
-      | jq -r '.path,(.inputs|to_entries[].value.path)' \
-      | cachix push "{{ cache_name }}"
-
-cache-shell cache_name="altf4llc-os":
-    nix develop --profile "dev-profile" -c true
-    cachix push "{{ cache_name }}" "dev-profile"
-
 check:
     nix flake check
 

--- a/justfile
+++ b/justfile
@@ -2,6 +2,8 @@ _default:
     just --list
 
 build profile:
+    #!/usr/bin/env bash
+    set -euxo pipefail
     nix build --json --no-link --print-build-logs "{{ profile }}" \
     | jq -r ".[0].outputs.out"
 

--- a/justfile
+++ b/justfile
@@ -10,25 +10,25 @@ build profile:
 check:
     nix flake check
 
-build-template template:
+build-template template temp_dir="$(mktemp -d)":
     #!/usr/bin/env bash
     set -euxo pipefail
     OUTPUT_DIR=$(just build "$PWD#example-{{ template }}")
-    TEMP_DIR=$(mktemp -d)
+    TEMP_DIR={{ temp_dir }}
     cp --no-preserve=mode -r $OUTPUT_DIR/* $TEMP_DIR/.
     echo $TEMP_DIR
 
-build-darwin system="x86_64":
+build-darwin system="x86_64" temp_dir="$(mktemp -d)":
     #!/usr/bin/env bash
     set -euxo pipefail
-    TEMP_DIR=$(just build-template "darwin")
+    TEMP_DIR=$(just build-template "darwin" "{{ temp_dir }}")
     ls -alh $TEMP_DIR
     just build "$TEMP_DIR#darwinConfigurations.{{ system }}.config.system.build.toplevel"
 
-build-home-manager system="x86_64-linux":
+build-home-manager system="x86_64-linux" temp_dir="$(mktemp -d)":
     #!/usr/bin/env bash
     set -euxo pipefail
-    TEMP_DIR=$(just build-template "home-manager")
+    TEMP_DIR=$(just build-template "home-manager" "{{ temp_dir }}")
     ls -alh $TEMP_DIR
     just build "$TEMP_DIR#homeConfigurations.{{ system }}.activationPackage"
 

--- a/justfile
+++ b/justfile
@@ -1,35 +1,52 @@
-temp_dir := "/tmp/kickstart.nix"
-
 _default:
     just --list
 
 build profile:
-    nix build --json --no-link --print-build-logs "{{ profile }}"
+    nix build --json --no-link --print-build-logs "{{ profile }}" \
+    | jq -r ".[0].outputs.out"
 
 check:
     nix flake check
 
-clean-template template:
-    rm -rf {{ temp_dir }}/{{ template }}
-    mkdir -p {{ temp_dir }}/{{ template }}
-
-build-template template: (clean-template template)
+build-template template:
     #!/usr/bin/env bash
-    DERIVATION=$(just build ".#example-{{ template }}")
-    OUTPUT=$(echo $DERIVATION | jq -r ".[0].outputs.out")
-    cp --no-preserve=mode -r $OUTPUT/* {{ temp_dir }}/{{ template }}
+    set -euxo pipefail
+    OUTPUT_DIR=$(just build "$PWD#example-{{ template }}")
+    TEMP_DIR=$(mktemp -d)
+    cp --no-preserve=mode -r $OUTPUT_DIR/* $TEMP_DIR/.
+    echo $TEMP_DIR
 
-build-darwin system="x86_64": (build-template "darwin")
-    just build "{{ temp_dir }}/darwin#darwinConfigurations.{{ system }}.config.system.build.toplevel"
+build-darwin system="x86_64":
+    #!/usr/bin/env bash
+    set -euxo pipefail
+    TEMP_DIR=$(just build-template "darwin")
+    ls -alh $TEMP_DIR
+    just build "$TEMP_DIR#darwinConfigurations.{{ system }}.config.system.build.toplevel"
 
-build-home-manager system="x86_64-linux": (build-template "home-manager")
-    just build "{{ temp_dir }}/home-manager#homeConfigurations.{{ system }}.activationPackage"
+build-home-manager system="x86_64-linux":
+    #!/usr/bin/env bash
+    set -euxo pipefail
+    TEMP_DIR=$(just build-template "home-manager")
+    ls -alh $TEMP_DIR
+    just build "$TEMP_DIR#homeConfigurations.{{ system }}.activationPackage"
 
-build-language template profile="default": (build-template template)
-    just build "{{ temp_dir }}/{{ template }}#{{ profile }}"
+build-language language profile="default":
+    #!/usr/bin/env bash
+    set -euxo pipefail
+    TEMP_DIR=$(just build-template "{{ language }}")
+    ls -alh $TEMP_DIR
+    just build "$TEMP_DIR"
 
-build-nixos-desktop system="x86_64" desktop="gnome": (build-template 'nixos-desktop-'+desktop)
-    just build "{{ temp_dir }}/nixos-desktop-{{ desktop }}#nixosConfigurations.{{ system }}.config.system.build.toplevel"
+build-nixos-desktop system="x86_64" desktop="gnome":
+    #!/usr/bin/env bash
+    set -euxo pipefail
+    TEMP_DIR=$(just build-template "nixos-desktop-{{ desktop }}")
+    ls -alh $TEMP_DIR
+    just build "$TEMP_DIR#nixosConfigurations.{{ system }}.config.system.build.toplevel"
 
-build-nixos-minimal system="x86_64": (build-template "nixos-minimal")
-    just build "{{ temp_dir }}/nixos-minimal#nixosConfigurations.{{ system }}.config.system.build.toplevel"
+build-nixos-minimal system="x86_64":
+    #!/usr/bin/env bash
+    set -euxo pipefail
+    TEMP_DIR=$(just build-template "nixos-minimal")
+    ls -alh $TEMP_DIR
+    just build "$TEMP_DIR#nixosConfigurations.{{ system }}.config.system.build.toplevel"

--- a/justfile
+++ b/justfile
@@ -18,17 +18,17 @@ build-template template temp_dir="$(mktemp -d)":
     cp --no-preserve=mode -r $OUTPUT_DIR/* $TEMP_DIR/.
     echo $TEMP_DIR
 
-build-darwin system="x86_64" temp_dir="$(mktemp -d)":
+build-darwin system="x86_64":
     #!/usr/bin/env bash
     set -euxo pipefail
-    TEMP_DIR=$(just build-template "darwin" "{{ temp_dir }}")
+    TEMP_DIR=$(just build-template "darwin")
     ls -alh $TEMP_DIR
     just build "$TEMP_DIR#darwinConfigurations.{{ system }}.config.system.build.toplevel"
 
-build-home-manager system="x86_64-linux" temp_dir="$(mktemp -d)":
+build-home-manager system="x86_64-linux":
     #!/usr/bin/env bash
     set -euxo pipefail
-    TEMP_DIR=$(just build-template "home-manager" "{{ temp_dir }}")
+    TEMP_DIR=$(just build-template "home-manager")
     ls -alh $TEMP_DIR
     just build "$TEMP_DIR#homeConfigurations.{{ system }}.activationPackage"
 

--- a/template/haskell/example.cabal
+++ b/template/haskell/example.cabal
@@ -67,7 +67,7 @@ executable example
     -- other-extensions:
 
     -- Other library packages from which modules are imported.
-    build-depends:    base ^>=4.17.2.1
+    build-depends:    base ^>=4.18.2.1
 
     -- Directories containing source files.
     hs-source-dirs:   app

--- a/template/haskell/flake.nix
+++ b/template/haskell/flake.nix
@@ -29,11 +29,11 @@
         };
         packages = {
           default = mkDerivation {
-            pname = name;
             inherit version;
-            src = ./.;
-            license = "";
             description = "";
+            license = "";
+            pname = name;
+            src = ./.;
           };
 
           docker = buildImage {

--- a/template/vite-react/flake.nix
+++ b/template/vite-react/flake.nix
@@ -17,7 +17,6 @@
       }: let
         name = "example";
         version = "0.1.0";
-        nodejs = pkgs.nodejs_21;
       in {
         devShells = {
           default = pkgs.mkShell {
@@ -28,7 +27,7 @@
 
         packages = {
           default = pkgs.buildNpmPackage {
-            inherit version nodejs;
+            inherit version;
             pname = name;
             src = ./.;
             npmDepsHash = "sha256-KeXRIp4qNywb1sy5lXTagoUsW6EeK1kF5OWJ97w9Vfk=";


### PR DESCRIPTION
### Added
- `CACHIX_BINARY_CACHE` environment variable across workflows.

### Changed
- Updated `cachix/cachix-action` from v12 to v14.
- Updated checkout action from v3 to v4.
- Simplified build commands in workflows.
- Updated `flake.lock` dependencies to newer revisions.

### Removed
- Removed `cache-build`, `cache-inputs`, and `cache-shell` from `justfile`.
