### PR TITLE
feat(go): update flake templates to use Go 1.22

### DIFF
--- a/template/go-mod/flake.nix
+++ b/template/go-mod/flake.nix
@@ -3,46 +3,42 @@
 
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
-  outputs = inputs @ {flake-parts, ...}:
-    flake-parts.lib.mkFlake {inherit inputs;} {
-      systems = ["x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin"];
+  outputs = inputs @ { flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ];
 
-      perSystem = {
-        config,
-        self',
-        inputs',
-        pkgs,
-        system,
-        ...
-      }: let
-        name = "example";
-        version = "latest";
-        vendorHash = null; # update whenever go.mod changes
-      in {
-        devShells = {
-          default = pkgs.mkShell {
-            inputsFrom = [self'.packages.default];
-          };
-        };
-
-        packages = {
-          default = pkgs.buildGoModule {
-            inherit name vendorHash;
-            src = ./.;
-            subPackages = ["cmd/example"];
+      perSystem = { config, pkgs, ... }:
+        let
+          name = "example";
+          version = "latest";
+          vendorHash = null; # update whenever go.mod changes
+        in
+        {
+          devShells = {
+            default = pkgs.mkShell {
+              buildInputs = [ pkgs.go_1_22 ];
+              inputsFrom = [ config.packages.default ];
+            };
           };
 
-          docker = pkgs.dockerTools.buildImage {
-            inherit name;
-            tag = version;
-            config = {
-              Cmd = ["${self'.packages.default}/bin/${name}"];
-              Env = [
-                "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
-              ];
+          packages = {
+            default = pkgs.buildGo122Module {
+              inherit name vendorHash;
+              src = ./.;
+              subPackages = [ "cmd/example" ];
+            };
+
+            docker = pkgs.dockerTools.buildImage {
+              inherit name;
+              tag = version;
+              config = {
+                Cmd = [ "${config.packages.default}/bin/${name}" ];
+                Env = [
+                  "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+                ];
+              };
             };
           };
         };
-      };
     };
 }

--- a/template/go-mod/go.mod
+++ b/template/go-mod/go.mod
@@ -1,3 +1,3 @@
 module github.com/example/example
 
-go 1.21.4
+go 1.22

--- a/template/go-pkg/flake.nix
+++ b/template/go-pkg/flake.nix
@@ -3,47 +3,42 @@
 
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
-  outputs = inputs @ {flake-parts, ...}:
-    flake-parts.lib.mkFlake {inherit inputs;} {
-      systems = ["x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin"];
+  outputs = inputs @ { flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ];
 
-      perSystem = {
-        config,
-        self',
-        inputs',
-        pkgs,
-        system,
-        ...
-      }: let
-        name = "example";
-        version = "latest";
-      in {
-        devShells = {
-          default = pkgs.mkShell {
-            inputsFrom = [self'.packages.default];
-          };
-        };
-
-        packages = {
-          default = pkgs.buildGoPackage {
-            inherit name;
-            goDeps = ./deps.nix;
-            goPackagePath = "github.com/example/${name}";
-            src = ./.;
-            subPackages = ["cmd/example"];
+      perSystem = { config, pkgs, ... }:
+        let
+          name = "example";
+          version = "latest";
+        in
+        {
+          devShells = {
+            default = pkgs.mkShell {
+              inputsFrom = [ config.packages.default ];
+            };
           };
 
-          docker = pkgs.dockerTools.buildImage {
-            inherit name;
-            tag = version;
-            config = {
-              Cmd = ["${self'.packages.default}/bin/${name}"];
-              Env = [
-                "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
-              ];
+          packages = {
+            default = pkgs.buildGo122Package {
+              inherit name;
+              goDeps = ./deps.nix;
+              goPackagePath = "github.com/example/${name}";
+              src = ./.;
+              subPackages = [ "cmd/example" ];
+            };
+
+            docker = pkgs.dockerTools.buildImage {
+              inherit name;
+              tag = version;
+              config = {
+                Cmd = [ "${config.packages.default}/bin/${name}" ];
+                Env = [
+                  "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+                ];
+              };
             };
           };
         };
-      };
     };
 }


### PR DESCRIPTION
## Changes

- Updates Flake templates for Go (`go-mod`, `go-pkg`) to use `go_1_22` and `buildGo122{Module,Package}`.