### PR TITLE
Add `.gitignore` to Rust Template to Exclude `.direnv` and `/target`

### DIFF
--- a/template/rust/.gitignore
+++ b/template/rust/.gitignore
@@ -1,0 +1,2 @@
+/target
+.direnv


### PR DESCRIPTION
This change adds a `.gitignore` file to the Rust template to ensure that the `.direnv` and `/target` are not committed to git repositories.