### PR TITLE
fix(nix): default to disabled system flake registries

### DIFF
--- a/template/darwin/module/configuration.nix
+++ b/template/darwin/module/configuration.nix
@@ -6,6 +6,7 @@
     settings = {
       builders-use-substitutes = true;
       experimental-features = ["flakes" "nix-command"];
+      flake-registry = builtins.toFile "null-flake-registry.json" ''{"flakes":[],"version":2}'';
       substituters = ["https://nix-community.cachix.org"];
       trusted-public-keys = [
         "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="

--- a/template/nixos-desktop/module/configuration.nix
+++ b/template/nixos-desktop/module/configuration.nix
@@ -22,6 +22,7 @@
     settings = {
       builders-use-substitutes = true;
       experimental-features = ["nix-command" "flakes"];
+      flake-registry = builtins.toFile "null-flake-registry.json" ''{"flakes":[],"version":2}'';
       substituters = [
         "https://nix-community.cachix.org"
       ];

--- a/template/nixos-minimal/module/configuration.nix
+++ b/template/nixos-minimal/module/configuration.nix
@@ -6,6 +6,7 @@
     settings = {
       builders-use-substitutes = true;
       experimental-features = ["nix-command" "flakes"];
+      flake-registry = builtins.toFile "null-flake-registry.json" ''{"flakes":[],"version":2}'';
       substituters = [
         "https://nix-community.cachix.org"
       ];


### PR DESCRIPTION
- [x] resolves #99, the root cause of #96 having previously escaped detection in CI or locally