### PR TITLE
fix: add explicit input of flake-parts in nim template

### DIFF
--- a/template/nim/flake.nix
+++ b/template/nim/flake.nix
@@ -1,7 +1,10 @@
 {
   description = "Kickstart Nim package flake.";
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+  };
 
   outputs = inputs @ {flake-parts, ...}:
     flake-parts.lib.mkFlake {inherit inputs;} {


### PR DESCRIPTION
Like discussed in #85 I added an explicit input of flake parts.

#### References
- hercules-ci/flake-parts#210
- #97 